### PR TITLE
fix(success-page): handle undefined array key error

### DIFF
--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -7,8 +7,8 @@
 $order = $block->getOrder();
 $paymentInfo = $order->getPayment()->getAdditionalInformation();
 
-$qrcodepix = $paymentInfo['qrcode'];
-$payloadPix = $paymentInfo['payload_pix'];
+$qrcodepix = $paymentInfo['qrcode'] ?? '';
+$payloadPix = $paymentInfo['payload_pix'] ?? '';
 ?>
 <?php if ($order->getPayment()->getMethod() === 'gfnl_pixqrcode'): ?>
     <div class="gfnl_pix">


### PR DESCRIPTION
**Pull Request Description**

### Description
This pull request addresses issue #1, which was about an "undefined array key" error on the success page. The error occurred due to accessing an undefined array key without proper validation. 

### Related Issue
Closes #1